### PR TITLE
Debug : AVM.progressivelyChangeVectorVariableSize

### DIFF
--- a/src/main/java/org/avmframework/AVM.java
+++ b/src/main/java/org/avmframework/AVM.java
@@ -208,7 +208,6 @@ public class AVM {
     private void progressivelyChangeVectorVariableSize(VectorVariable vectorVar,
                                                        ObjectiveValue current,
                                                        boolean increase) throws TerminationException {
-        int currentSize, nextSize = vectorVar.size();
         ObjectiveValue next = null;
 
         // try moves that increase the vector size
@@ -216,18 +215,14 @@ public class AVM {
             if (next != null) {
                 current = next;
             }
-            currentSize = nextSize;
 
             changeVectorVariableSize(vectorVar, increase);
 
             next = objFun.evaluate(vector);
-            nextSize = currentSize;
         } while (next.betterThan(current));
 
         // reverse the last move, if there was a change
-        if (nextSize > currentSize) {
-            changeVectorVariableSize(vectorVar, !increase);
-        }
+        changeVectorVariableSize(vectorVar, !increase);
     }
 
     /**


### PR DESCRIPTION
 I found some problems with avmf running an example _StringOptimization_.
 On my trials, avmf always found the exact solution except for the one last letter like
    "Alternating Variable Methoe"
 or the exact solution plus some garbage letters like
    "Alternating Variable Methodw7Fkh]b0Qzhl{/~@>/"
in the limitation of 1000 maxEvaluations.
 I think the part of avmf that changes the size of vector, namely **AVM.progressivelyChangeVectorVariableSize**, is buggy because the reversing the last move seems to never execute. 
```
    // reverse the last move, if there was a change
    if (nextSize > currentSize) {
        changeVectorVariableSize(vectorVar, !increase);
    }
```
 Also i think the reversing should be done unconditionally because the size is modified in the do-while loop whenever progressivelyChangeVectorVariableSize is called

 The variables **currentSize**, and **nextSize** are not used anymore, so I removed them too.